### PR TITLE
Correct name of rotated tgz files

### DIFF
--- a/etc/logrotate/logrotate.conf
+++ b/etc/logrotate/logrotate.conf
@@ -32,7 +32,7 @@
 {
 	su tpot tpot
         copytruncate
-        create 770 tpot tpot
+        create 660 tpot tpot
 	daily
         missingok
         notifempty
@@ -51,9 +51,10 @@
 {
 	su tpot tpot
         copytruncate
-        create 770 tpot tpot
+        create 660 tpot tpot
 	daily
         missingok
         notifempty
 	rotate 30
+	addextension .tgz
 }


### PR DESCRIPTION
Added extension .tgz to logrotate.conf, so instead of: bistreams.tgz.1 logrotate create bistreams.1.tgz, also removed executable bit from compressed files.